### PR TITLE
fix: replace next/image with img tag to fix blurry images on website.

### DIFF
--- a/components/teams/TeamCard.js
+++ b/components/teams/TeamCard.js
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { FaEnvelope, FaGithub, FaLinkedin } from 'react-icons/fa';
 import Style from './Team.module.css';
 
@@ -8,16 +7,11 @@ function TeamCard({ name, title, company, socials, imageSrc, lazyImageSrc }) {
   return (
     <div className={Style.card}>
       <div className="z-10 w-full text-center h-2/3 mb-18 mt-4 overflow-hidden rounded-lg">
-        <Image
-          className="z-10 rounded-lg object-cover object-top"
-          height="100%"
-          width="100%"
-          layout="responsive"
+        <img
+          className="z-10 rounded-lg object-cover object-top w-full h-full"
           src={imageSrc}
           alt={name}
-          quality={100}
-          placeholder="blur"
-          blurDataURL={lazyImageSrc}
+          loading="lazy"
         />
       </div>
       <div className="z-10 text-center my-5">


### PR DESCRIPTION
Since the images load properly in local runs, the issue is related to deployment. There is a Next.js Image component that uses Sharp library for image size optimization which is broken in the Netlify environment. I have replaced the Image component with img tag for now, this will keep the images at original size and it will take a while to load.

<img width="2876" height="1482" alt="image" src="https://github.com/user-attachments/assets/d563ed90-7bc1-4c8c-aa4b-4922a9a03f76" />
